### PR TITLE
Fix upgrade scripts to follow changed sfctl upgrade command options

### DIFF
--- a/Actors/ActorCounter/Scripts/upgrade.sh
+++ b/Actors/ActorCounter/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../CounterActorApplication"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -17,7 +23,7 @@ if [ $? -ne 0 ]; then
 fi
 
 version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
-eval sfctl application upgrade --app-id CounterActorApplication --app-version ${version} --parameters "" --mode "Monitored"
+eval sfctl application upgrade --app-id fabric:/CounterActorApplication --app-version ${version} --parameters [] --mode "Monitored"
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."
     exit 1

--- a/Actors/ActorCounter/Scripts/upgrade.sh
+++ b/Actors/ActorCounter/Scripts/upgrade.sh
@@ -22,7 +22,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 eval sfctl application upgrade --app-id fabric:/CounterActorApplication --app-version ${version} --parameters [] --mode "Monitored"
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."

--- a/Actors/VisualObjectActor/Scripts/upgrade.sh
+++ b/Actors/VisualObjectActor/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../VisualObjectApplication"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -18,11 +24,10 @@ fi
 
 # Check parameters to see if InstanceCount was previously specified
 params=$(sfctl application info --application-id VisualObjectApplication --query "parameters[].[key, value][]")
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 if [[ $params =~ "InstanceCount" ]]; then
-    sfctl application upgrade --app-id VisualObjectApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/VisualObjectApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
 else
-    sfctl application upgrade --app-id VisualObjectApplication --app-version ${version} --parameters "" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/VisualObjectApplication --app-version ${version} --parameters [] --mode "Monitored"
 fi
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."

--- a/Services/EchoServer/EchoServer1.0/Scripts/upgrade.sh
+++ b/Services/EchoServer/EchoServer1.0/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../EchoServerApplication"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -18,12 +24,12 @@ fi
 
 # Check parameters to see if InstanceCount was previously specified
 params=$(sfctl application info --application-id EchoServerApplication --query "parameters[].[key, value][]")
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 if [[ $params =~ "InstanceCount" ]]; then
-    sfctl application upgrade --app-id EchoServerApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/EchoServerApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode Monitored
 else
-    sfctl application upgrade --app-id EchoServerApplication --app-version ${version} --parameters "" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/EchoServerApplication --app-version ${version} --parameters [] --mode "Monitored"
 fi
+
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."
     exit 1

--- a/Services/EchoServer/EchoServer2.0/Scripts/upgrade.sh
+++ b/Services/EchoServer/EchoServer2.0/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../EchoServerApplication2"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -18,12 +24,12 @@ fi
 
 # Check parameters to see if InstanceCount was previously specified
 params=$(sfctl application info --application-id EchoServerApplication --query "parameters[].[key, value][]")
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 if [[ $params =~ "InstanceCount" ]]; then
-    sfctl application upgrade --app-id EchoServerApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/EchoServerApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
 else
-    sfctl application upgrade --app-id EchoServerApplication --app-version ${version} --parameters "" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/EchoServerApplication --app-version ${version} --parameters [] --mode "Monitored"
 fi
+
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."
     exit 1

--- a/Services/Gateway/Scripts/upgrade.sh
+++ b/Services/Gateway/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../GatewayApplication"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -18,12 +24,12 @@ fi
 
 # Check parameters to see if InstanceCount was previously specified
 params=$(sfctl application info --application-id GatewayApplication --query "parameters[].[key, value][]")
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 if [[ $params =~ "InstanceCount" ]]; then
-    sfctl application upgrade --app-id GatewayApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/GatewayApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
 else
-    sfctl application upgrade --app-id GatewayApplication --app-version ${version} --parameters "" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/GatewayApplication --app-version ${version} --parameters [] --mode "Monitored"
 fi
+
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."
     exit 1

--- a/Services/JenkinsDocker/Scripts/upgrade.sh
+++ b/Services/JenkinsDocker/Scripts/upgrade.sh
@@ -22,7 +22,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 eval sfctl application upgrade --app-id fabric:/JenkinsSF --app-version ${version} --parameters [] --mode "Monitored"
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."

--- a/Services/JenkinsDocker/Scripts/upgrade.sh
+++ b/Services/JenkinsDocker/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../JenkinsSF"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -17,7 +23,7 @@ if [ $? -ne 0 ]; then
 fi
 
 version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
-eval sfctl application upgrade --app-id JenkinsSF --app-version ${version} --parameters "" --mode "Monitored"
+eval sfctl application upgrade --app-id fabric:/JenkinsSF --app-version ${version} --parameters [] --mode "Monitored"
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."
     exit 1

--- a/Services/WatchDog/Scripts/upgrade.sh
+++ b/Services/WatchDog/Scripts/upgrade.sh
@@ -4,6 +4,12 @@ set -x
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 appPkg="$DIR/../WatchdogApplication"
 
+if [[ "$#" != "0" ]];then
+        version="$1"
+else
+        version="1.0.0"
+fi
+
 sfctl application upload --path $appPkg --show-progress
 if [ $? -ne 0 ]; then
     echo "Application copy failed."
@@ -18,11 +24,10 @@ fi
 
 # Check parameters to see if InstanceCount was previously specified
 params=$(sfctl application info --application-id WatchdogApplication --query "parameters[].[key, value][]")
-version=$(sed -e "s/xmlns/ignore/" $appPkg/ApplicationManifest.xml | xmllint --xpath "string(//ApplicationManifest/@ApplicationTypeVersion)" -)
 if [[ $params =~ "InstanceCount" ]]; then
-    sfctl application upgrade --app-id WatchdogApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/WatchdogApplication --app-version ${version} --parameters "{\"InstanceCount\":\"-1\"}" --mode "Monitored"
 else
-    sfctl application upgrade --app-id WatchdogApplication --app-version ${version} --parameters "" --mode "Monitored"
+    sfctl application upgrade --app-id fabric:/WatchdogApplication --app-version ${version} --parameters [] --mode "Monitored"
 fi
 if [ $? -ne 0 ]; then
     echo "Upgrade of application failed."


### PR DESCRIPTION
Fix upgrade scripts to follow changed sfctl upgrade command options and work with eclipse as well (removed xmllint)